### PR TITLE
update requirements & validation output dir cross-project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tinydb==3.2.2
+tinydb==3.6.0
 google_api_python_client==1.6.1
 jinja2==2.9.5
 ipaddress

--- a/x_project.py
+++ b/x_project.py
@@ -1,4 +1,5 @@
 import json
+import os
 import logging
 from jinja2 import Environment, PackageLoader
 from tinydb import TinyDB, Query

--- a/x_project.py
+++ b/x_project.py
@@ -16,7 +16,16 @@ env.filters['pretty_print'] = pretty_print
 
 def generate_cross_project_page(header, fields, dropdowns, findings, rule_title):
     template = env.get_template("finding_template.html")
-    file = open("Report Output/cross-project/" + rule_title + ".html", "w+")
+    output_dir = "Report Output/cross-project/rules/"
+    if not os.path.isdir(output_dir):
+        try:
+            os.makedirs(output_dir)
+        except Exception as e:
+            msg = "could not make output directory '%s'. The error encountered was: %s%s%sStack trace:%s%s" % (output_dir, e, os.linesep, os.linesep, os.linesep, traceback.format_exc())
+            print("Error: %s" % (msg))
+            logging.exception(msg)
+
+    file = open("Report Output/cross-project/rules/" + rule_title + ".html", "w+")
     file.write(template.render(
         **{"records": findings, "dropdowns": dropdowns, "header": header, "fields": fields,
             "text": rule_title}))


### PR DESCRIPTION
* To use x_project it's necessary update tinydb version (3.2.2 -> 3.6.0).
```
$ python ../G-Scout/x_project.py
Traceback (most recent call last):
  File "../G-Scout/x_project.py", line 44, in <module>
    x_project_findings(rules)
  File "../G-Scout/x_project.py", line 40, in x_project_findings
    entity = project_db.table(finding['entity']['table']).get(doc_id = finding['entity']['id'])
TypeError: get() got an unexpected keyword argument 'doc_id'
```

* The template _finding_template.html & base.html_ use static file, so it's necessary three levels of directories for cross-project report.

```
output_dir = "Report Output/cross-project/rules/"
```
``` 
<link rel="stylesheet" href="../../../assets/templates/bootstrap.min.css">
<link rel="stylesheet" type="text/css" href="../../../assets/templates/custom.css"/>
<script src="../../../assets/templates/jquery.min.js"></script>
<script src="../../../assets/templates/bootstrap.min.js"></script>
<link rel="shortcut icon" type="image/png" href="../../../assets/icon.png"/>
```

* If the dir `Report Output/cross-project/rules/`don't exist, it's necessary create this directory.